### PR TITLE
Added support for several basic OPC UA data types

### DIFF
--- a/ua_driver.go
+++ b/ua_driver.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"strings"
 	"sync"
 	"time"
-	"strings"
 )
 
 type cache map[string]string
@@ -216,7 +216,7 @@ func (d *OPCUA_Driver) UpdateAliases(changes []map[string]interface{}) {
 	}
 }
 
-func (d *OPCUA_Driver) handlerOnChange(monId uint32, val int, status uint32) {
+func (d *OPCUA_Driver) handlerOnChange(monId uint32, val interface{}, status uint32) {
 	tag := d.Client.sub.monitors[monId]
 	tag.Data = val
 	tag.Quality = status


### PR DESCRIPTION
Added support for the following OPC UA data types

- Boolean
- SByte
- Byte
- Int16
- UInt16
- Int32
- UInt32
- Int64
- UInt64
- Float
- Double
- String
- DateTime
- ByteString

Kept default int return on unknown type for compatibility with any existing code